### PR TITLE
Update deployment workflow to use new GitHub Pages action and simplif…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,36 +43,10 @@ jobs:
         run: npm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3.9.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: ${{ github.ref_name }}
-
-  cleanup:
-    runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'delete' && github.event.ref_type == 'branch' && github.ref != 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
-
-    steps:
-      - name: Determine Branch Name
-        id: vars
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          elif [[ "${{ github.event_name }}" == "delete" ]]; then
-            BRANCH_NAME="${{ github.ref }}"
-            BRANCH_NAME="${BRANCH_NAME#refs/heads/}"
-          else
-            echo "Unsupported event type: ${{ github.event_name }}"
-            exit 1
-          fi
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
-
-      - name: Delete Folder in `gh-pages` Branch
-        run: |
-          echo "Deleting folder $BRANCH_NAME in gh-pages branch"
-          curl -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/contents/${{ env.BRANCH_NAME }}?ref=gh-pages"
+          branch: gh-pages
+          folder: dist
+          clean: true
+          clean-exclude: "main"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,11 +42,24 @@ jobs:
       - name: Run build script
         run: npm run build
 
+      - name: Fetch Open PR Branch Names
+        id: fetch-pr-branches
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="duncanhunter/custom-element-kit"
+          PR_BRANCHES=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$REPO/pulls?state=open" | jq -r '.[].head.ref' | paste -sd "\n" -)
+          echo "PR_BRANCHES=${PR_BRANCHES}" >> $GITHUB_ENV
+
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: dist
+          target-folder: ${{ github.ref_name}}
           clean: true
-          clean-exclude: "main"
+          clean-exclude: |
+            main
+            ${{ env.PR_BRANCHES }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to use a different GitHub Pages deployment action and simplifies the cleanup process.

Deployment updates:

* Changed the GitHub Pages deployment action from `peaceiris/actions-gh-pages@v3.9.1` to `JamesIves/github-pages-deploy-action@v4`. This new action includes parameters for specifying the branch, folder, and cleanup options. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL46-R52](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L46-R52))

Cleanup simplification:

* Removed the entire `cleanup` job, which included steps to determine the branch name and delete the corresponding folder in the `gh-pages` branch. The new deployment action handles cleanup more efficiently with the `clean` and `clean-exclude` parameters. (`.github/workflows/deploy.yml`, [.github/workflows/deploy.ymlL46-R52](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L46-R52))…y cleanup steps